### PR TITLE
Iss3 - Problem with slots with multiple signatures

### DIFF
--- a/pydm/epics_plugin.py
+++ b/pydm/epics_plugin.py
@@ -38,16 +38,6 @@ class Connection(PyDMConnection):
       
   def send_connection_state(self, pvname=None, conn=None, *args, **kws):
     self.connection_state_signal.emit(conn)
-  
-  '''
-  @pyqtSlot(str)
-  def put_value(self, new_val):
-    self.pv.put(str(new_val))
-  
-  @pyqtSlot(np.ndarray)
-  def put_value(self, new_waveform_val):
-    self.pv.put(new_waveform_val)
-  '''
 
   @pyqtSlot(str)
   @pyqtSlot(np.ndarray)

--- a/pydm/epics_plugin.py
+++ b/pydm/epics_plugin.py
@@ -39,6 +39,7 @@ class Connection(PyDMConnection):
   def send_connection_state(self, pvname=None, conn=None, *args, **kws):
     self.connection_state_signal.emit(conn)
   
+  '''
   @pyqtSlot(str)
   def put_value(self, new_val):
     self.pv.put(str(new_val))
@@ -46,7 +47,16 @@ class Connection(PyDMConnection):
   @pyqtSlot(np.ndarray)
   def put_value(self, new_waveform_val):
     self.pv.put(new_waveform_val)
-    
+  '''
+
+  @pyqtSlot(str)
+  @pyqtSlot(np.ndarray)
+  def put_value(self, new_val):
+    if isinstance(new_val, np.ndarray):
+      self.pv.put(new_val)
+    elif isinstance(new_val, str):
+      self.pv.put(str(new_val))
+
   def add_listener(self, channel):
     super(Connection, self).add_listener(channel)
     #If we are adding a listener to an already existing PV, we need to


### PR DESCRIPTION
Method **put_value(self, new_val)** of epics_plugin.py had two implementations, each one with a different pyqtslot decorator: **@pyqtSlot(str)** and **@pyqtSlot(np.ndarray)**. This led to problems in PyQt4.8 and PyQt5.x because only the last implementation done seens to be considered by these versions.

To solve it, both implementations were merged into a single method **put_value(self, new_val)** and both decorators were applied to it. So **put_value** remains accepting only **str** and **np.narray** as input, but now they are treated by the same method. Input instance is checked inside the method so each type of instance can be processed correctly.